### PR TITLE
fix: rgb(a) to hex conversion

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,14 +36,16 @@ export const commands = {
     // color library drops the alpha for hex :(
     transform: () =>
       replaceColorText(color => {
-        const rgbColor = color.rgb().object();
+        const { alpha } = color.object();
 
-        const red = Math.round(rgbColor.r).toString(16);
-        const green = Math.round(rgbColor.g).toString(16);
-        const blue = Math.round(rgbColor.b).toString(16);
-        const alpha = rgbColor.alpha ? Math.round(255 * rgbColor.alpha).toString(16) : '';
+        const alphaString =
+          alpha !== undefined
+            ? Math.round(255 * alpha)
+                .toString(16)
+                .padStart(2, "0")
+            : "";
 
-        return '#' + red + green + blue + alpha;
+        return color.hex() + alphaString;
       })
   },
   hsl: {


### PR DESCRIPTION
Currently the extension makes the following incorrect conversions:
`rgb(0, 0, 255)` -> `#00ff` (should be `#00f`)
`rgba(0, 0, 0, 0.02)` -> `#0005` (should be `#00000005`)
`rgba(0, 0, 0, 0)` -> `#000` (should be `#0000` or `#00000000`)

This PR makes sure the hex representation of the output is always two characters per color component. It also handles the case where opacity is 0.